### PR TITLE
Ability to swipe directly from kCellStateRight to kCellStateLeft and vice versa.

### DIFF
--- a/SWTableViewCell/SWTableViewCell.m
+++ b/SWTableViewCell/SWTableViewCell.m
@@ -346,7 +346,9 @@ typedef enum {
             } else if (velocity.x <= -0.5f) {
                 // No-op
             } else {
-                if (targetContentOffset->x > [self leftUtilityButtonsWidth] / 2)
+                if (targetContentOffset->x >= ([self utilityButtonsPadding] - [self rightUtilityButtonsWidth] / 2))
+                    [self scrollToRight:targetContentOffset];
+                else if (targetContentOffset->x > [self leftUtilityButtonsWidth] / 2)
                     [self scrollToCenter:targetContentOffset];
                 else
                     [self scrollToLeft:targetContentOffset];
@@ -358,7 +360,9 @@ typedef enum {
             } else if (velocity.x <= -0.5f) {
                 [self scrollToCenter:targetContentOffset];
             } else {
-                if (targetContentOffset->x < ([self utilityButtonsPadding] - [self rightUtilityButtonsWidth] / 2))
+                if (targetContentOffset->x <= [self leftUtilityButtonsWidth] / 2)
+                    [self scrollToLeft:targetContentOffset];
+                else if (targetContentOffset->x < ([self utilityButtonsPadding] - [self rightUtilityButtonsWidth] / 2))
                     [self scrollToCenter:targetContentOffset];
                 else
                     [self scrollToRight:targetContentOffset];


### PR DESCRIPTION
Previously, scroll view would snap to center if scrolled past the center when opened to the left or right.
Now, animates to the correct state when passed the respective thresholds
