### PR TITLE
Fix Misleading Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The index signifies which utility button the user pressed, for each side the but
 
 
 ##Contributing
-Use [Github issues](https://github.com/cewendel/tlog/issues) to track bugs and feature requests.
+Use [Github issues](https://github.com/cewendel/SWTableViewCell/issues) to track bugs and feature requests.
 
 
 ##Contact


### PR DESCRIPTION
The previous link linked to a different repo. This can cause a lot of confusion.
This Pull Request fixes that.
