### PR TITLE
Adding delegate method to determine when a cell's state has changed.

### DIFF
--- a/SWTableViewCell/SWTableViewCell.h
+++ b/SWTableViewCell/SWTableViewCell.h
@@ -11,11 +11,18 @@
 
 @class SWTableViewCell;
 
+typedef enum {
+    kCellStateCenter,
+    kCellStateLeft,
+    kCellStateRight
+} SWCellState;
+
 @protocol SWTableViewCellDelegate <NSObject>
 
 @optional
 - (void)swippableTableViewCell:(SWTableViewCell *)cell didTriggerLeftUtilityButtonWithIndex:(NSInteger)index;
 - (void)swippableTableViewCell:(SWTableViewCell *)cell didTriggerRightUtilityButtonWithIndex:(NSInteger)index;
+- (void)swippableTableViewCell:(SWTableViewCell *)cell scrollingToState:(SWCellState)state;
 
 @end
 

--- a/SWTableViewCell/SWTableViewCell.m
+++ b/SWTableViewCell/SWTableViewCell.m
@@ -13,12 +13,6 @@
 
 static NSString * const kTableViewCellContentView = @"UITableViewCellContentView";
 
-typedef enum {
-    kCellStateCenter,
-    kCellStateLeft,
-    kCellStateRight
-} SWCellState;
-
 
 #pragma mark - SWUtilityButtonView
 
@@ -269,6 +263,10 @@ typedef enum {
     // Scroll back to center
     [self.cellScrollView setContentOffset:CGPointMake([self leftUtilityButtonsWidth], 0) animated:animated];
     _cellState = kCellStateCenter;
+    
+    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
+        [_delegate swippableTableViewCell:self scrollingToState:kCellStateCenter];
+    }
 }
 
 
@@ -308,16 +306,28 @@ typedef enum {
 - (void)scrollToRight:(inout CGPoint *)targetContentOffset{
     targetContentOffset->x = [self utilityButtonsPadding];
     _cellState = kCellStateRight;
+    
+    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
+        [_delegate swippableTableViewCell:self scrollingToState:kCellStateRight];
+    }
 }
 
 - (void)scrollToCenter:(inout CGPoint *)targetContentOffset {
     targetContentOffset->x = [self leftUtilityButtonsWidth];
     _cellState = kCellStateCenter;
+
+    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
+        [_delegate swippableTableViewCell:self scrollingToState:kCellStateCenter];
+    }
 }
 
 - (void)scrollToLeft:(inout CGPoint *)targetContentOffset{
     targetContentOffset->x = 0;
     _cellState = kCellStateLeft;
+    
+    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
+        [_delegate swippableTableViewCell:self scrollingToState:kCellStateLeft];
+    }
 }
 
 #pragma mark UIScrollViewDelegate


### PR DESCRIPTION
Adding a delegate method to announce cell state changes is useful for cell-swipe dependency. For example, with this delegate method you can now implement logic to force only one cell to have its slide tray open. Since this library only deals with UITableViewCells, the controller of UITableView must implement the cell dependency.
