### PR TITLE
Set Custom Cell Height

### DIFF
--- a/SWTableViewCell/SWTableViewCell.h
+++ b/SWTableViewCell/SWTableViewCell.h
@@ -34,6 +34,7 @@ typedef enum {
 
 - (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier containingTableView:(UITableView *)containingTableView leftUtilityButtons:(NSArray *)leftUtilityButtons rightUtilityButtons:(NSArray *)rightUtilityButtons;
 
+- (void)setCellHeight:(CGFloat)height;
 - (void)setBackgroundColor:(UIColor *)backgroundColor;
 - (void)hideUtilityButtonsAnimated:(BOOL)animated;
 

--- a/SWTableViewCell/SWTableViewCell.m
+++ b/SWTableViewCell/SWTableViewCell.m
@@ -88,6 +88,15 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     }
 }
 
+- (void)setHeight:(CGFloat)height {
+    for (NSUInteger utilityButtonsCounter = 0; utilityButtonsCounter < _utilityButtons.count; utilityButtonsCounter++) {
+        UIButton *utilityButton = (UIButton *)_utilityButtons[utilityButtonsCounter];
+        CGFloat utilityButtonXCord = 0;
+        if (utilityButtonsCounter >= 1) utilityButtonXCord = _utilityButtonWidth * utilityButtonsCounter;
+        [utilityButton setFrame:CGRectMake(utilityButtonXCord, 0, _utilityButtonWidth, height)];
+    }
+}
+
 @end
 
 @interface SWTableViewCell () <UIScrollViewDelegate> {
@@ -248,6 +257,18 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor {
     self.scrollViewContentView.backgroundColor = backgroundColor;
+}
+
+#pragma mark Height methods
+
+- (void)setCellHeight:(CGFloat)height {
+    _height = height;
+    
+    // update the utility button height
+    [_scrollViewButtonViewLeft setHeight:height];
+    [_scrollViewButtonViewRight setHeight:height];
+    
+    [self layoutSubviews];
 }
 
 #pragma mark - Utility buttons handling


### PR DESCRIPTION
Adds ability to update cell height. Example use:

```
SWTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];

if (!cell) {
    NSMutableArray *rightUtilityButtons = [NSMutableArray new];

    [rightUtilityButtons sw_addUtilityButtonWithColor:
     [UIColor colorWithRed:0.78f green:0.78f blue:0.8f alpha:1.0]
                                                title:@"More"];

    [rightUtilityButtons sw_addUtilityButtonWithColor:
     [UIColor colorWithRed:1.0f green:0.231f blue:0.188 alpha:1.0f]
                                                title:@"Delete"];

    cell = [[DoNotUseTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier containingTableView:tableView leftUtilityButtons:nil rightUtilityButtons:rightUtilityButtons];
}

    cell = [[DoNotUseTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:cellIdentifier containingTableView:tableView leftUtilityButtons:nil rightUtilityButtons:rightUtilityButtons];
}

// specify custom cell height
[cell setCellHeight:100.0f];
```
