### PR TITLE
Refactored all instances of ‘Swippable’ to ‘Swipeable’ to fix typos.

### DIFF
--- a/SWTableViewCell/SWTableViewCell.h
+++ b/SWTableViewCell/SWTableViewCell.h
@@ -20,9 +20,9 @@ typedef enum {
 @protocol SWTableViewCellDelegate <NSObject>
 
 @optional
-- (void)swippableTableViewCell:(SWTableViewCell *)cell didTriggerLeftUtilityButtonWithIndex:(NSInteger)index;
-- (void)swippableTableViewCell:(SWTableViewCell *)cell didTriggerRightUtilityButtonWithIndex:(NSInteger)index;
-- (void)swippableTableViewCell:(SWTableViewCell *)cell scrollingToState:(SWCellState)state;
+- (void)swipeableTableViewCell:(SWTableViewCell *)cell didTriggerLeftUtilityButtonWithIndex:(NSInteger)index;
+- (void)swipeableTableViewCell:(SWTableViewCell *)cell didTriggerRightUtilityButtonWithIndex:(NSInteger)index;
+- (void)swipeableTableViewCell:(SWTableViewCell *)cell scrollingToState:(SWCellState)state;
 
 @end
 

--- a/SWTableViewCell/SWTableViewCell.m
+++ b/SWTableViewCell/SWTableViewCell.m
@@ -394,16 +394,16 @@ static BOOL containingScrollViewIsScrolling = false;
 - (void)rightUtilityButtonHandler:(id)sender {
     SWUtilityButtonTapGestureRecognizer *utilityButtonTapGestureRecognizer = (SWUtilityButtonTapGestureRecognizer *)sender;
     NSUInteger utilityButtonIndex = utilityButtonTapGestureRecognizer.buttonIndex;
-    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:didTriggerRightUtilityButtonWithIndex:)]) {
-        [_delegate swippableTableViewCell:self didTriggerRightUtilityButtonWithIndex:utilityButtonIndex];
+    if ([_delegate respondsToSelector:@selector(swipeableTableViewCell:didTriggerRightUtilityButtonWithIndex:)]) {
+        [_delegate swipeableTableViewCell:self didTriggerRightUtilityButtonWithIndex:utilityButtonIndex];
     }
 }
 
 - (void)leftUtilityButtonHandler:(id)sender {
     SWUtilityButtonTapGestureRecognizer *utilityButtonTapGestureRecognizer = (SWUtilityButtonTapGestureRecognizer *)sender;
     NSUInteger utilityButtonIndex = utilityButtonTapGestureRecognizer.buttonIndex;
-    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:didTriggerLeftUtilityButtonWithIndex:)]) {
-        [_delegate swippableTableViewCell:self didTriggerLeftUtilityButtonWithIndex:utilityButtonIndex];
+    if ([_delegate respondsToSelector:@selector(swipeableTableViewCell:didTriggerLeftUtilityButtonWithIndex:)]) {
+        [_delegate swipeableTableViewCell:self didTriggerLeftUtilityButtonWithIndex:utilityButtonIndex];
     }
 }
 
@@ -416,8 +416,8 @@ static BOOL containingScrollViewIsScrolling = false;
     });
     _cellState = kCellStateCenter;
     
-    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
-        [_delegate swippableTableViewCell:self scrollingToState:kCellStateCenter];
+    if ([_delegate respondsToSelector:@selector(swipeableTableViewCell:scrollingToState:)]) {
+        [_delegate swipeableTableViewCell:self scrollingToState:kCellStateCenter];
     }
 }
 
@@ -465,8 +465,8 @@ static BOOL containingScrollViewIsScrolling = false;
     self.longPressGestureRecognizer.enabled = NO;
     self.tapGestureRecognizer.enabled = NO;
     
-    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
-        [_delegate swippableTableViewCell:self scrollingToState:kCellStateRight];
+    if ([_delegate respondsToSelector:@selector(swipeableTableViewCell:scrollingToState:)]) {
+        [_delegate swipeableTableViewCell:self scrollingToState:kCellStateRight];
     }
 }
 
@@ -477,8 +477,8 @@ static BOOL containingScrollViewIsScrolling = false;
     self.longPressGestureRecognizer.enabled = YES;
     self.tapGestureRecognizer.enabled = NO;
 
-    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
-        [_delegate swippableTableViewCell:self scrollingToState:kCellStateCenter];
+    if ([_delegate respondsToSelector:@selector(swipeableTableViewCell:scrollingToState:)]) {
+        [_delegate swipeableTableViewCell:self scrollingToState:kCellStateCenter];
     }
 }
 
@@ -489,8 +489,8 @@ static BOOL containingScrollViewIsScrolling = false;
     self.longPressGestureRecognizer.enabled = NO;
     self.tapGestureRecognizer.enabled = NO;
     
-    if ([_delegate respondsToSelector:@selector(swippableTableViewCell:scrollingToState:)]) {
-        [_delegate swippableTableViewCell:self scrollingToState:kCellStateLeft];
+    if ([_delegate respondsToSelector:@selector(swipeableTableViewCell:scrollingToState:)]) {
+        [_delegate swipeableTableViewCell:self scrollingToState:kCellStateLeft];
     }
 }
 

--- a/SWTableViewCell/ViewController.m
+++ b/SWTableViewCell/ViewController.m
@@ -158,7 +158,7 @@
 
 #pragma mark - SWTableViewDelegate
 
-- (void)swippableTableViewCell:(SWTableViewCell *)cell didTriggerLeftUtilityButtonWithIndex:(NSInteger)index {
+- (void)swipeableTableViewCell:(SWTableViewCell *)cell didTriggerLeftUtilityButtonWithIndex:(NSInteger)index {
     switch (index) {
         case 0:
             NSLog(@"left button 0 was pressed");
@@ -176,7 +176,7 @@
     }
 }
 
-- (void)swippableTableViewCell:(SWTableViewCell *)cell didTriggerRightUtilityButtonWithIndex:(NSInteger)index {
+- (void)swipeableTableViewCell:(SWTableViewCell *)cell didTriggerRightUtilityButtonWithIndex:(NSInteger)index {
     switch (index) {
         case 0:
         {


### PR DESCRIPTION
'Swippable' is incorrect. Everything else in the library is fantastic, so this is a super minor change.
