### PR TITLE
If there are no utility buttons on a side, turn off scrolling in that direction

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -535,22 +535,27 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     self.tapGestureRecognizer.enabled = NO;
     if (scrollView.contentOffset.x > [self leftUtilityButtonsWidth])
     {
-        CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self rightUtilityButtonsWidth]);
-        
-        // Expose the right button view
-        self.scrollViewButtonViewRight.frame = CGRectMake(scrollView.contentOffset.x + (CGRectGetWidth(self.bounds) - scrollViewWidth), 0.0f, scrollViewWidth,self.height);
-        
-        CGRect scrollViewBounds = self.scrollViewButtonViewRight.bounds;
-        scrollViewBounds.origin.x = MAX([self rightUtilityButtonsWidth] - scrollViewWidth, [self rightUtilityButtonsWidth] - scrollView.contentOffset.x);
-        self.scrollViewButtonViewRight.bounds = scrollViewBounds;
+        if ([self rightUtilityButtonsWidth] > 0)
+        {
+            CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self rightUtilityButtonsWidth]);
+            
+            // Expose the right button view
+            self.scrollViewButtonViewRight.frame = CGRectMake(scrollView.contentOffset.x + (CGRectGetWidth(self.bounds) - scrollViewWidth), 0.0f, scrollViewWidth,self.height);
+            
+            CGRect scrollViewBounds = self.scrollViewButtonViewRight.bounds;
+            scrollViewBounds.origin.x = MAX([self rightUtilityButtonsWidth] - scrollViewWidth, [self rightUtilityButtonsWidth] - scrollView.contentOffset.x);
+            self.scrollViewButtonViewRight.bounds = scrollViewBounds;
+        }
     }
     else
     {
-        CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self leftUtilityButtonsWidth]);
-        
         // Expose the left button view
-        self.scrollViewButtonViewLeft.frame = CGRectMake([self leftUtilityButtonsWidth], 0.0f, scrollViewWidth, self.height);
-        
+        if ([self leftUtilityButtonsWidth] > 0)
+        {
+            CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self leftUtilityButtonsWidth]);
+            
+            self.scrollViewButtonViewLeft.frame = CGRectMake([self leftUtilityButtonsWidth], 0.0f, scrollViewWidth, self.height);
+        }
     }
 }
 


### PR DESCRIPTION
If there are no left utility buttons, as for the user experience, they should not be able to scroll the table view cell from the left side. While technically this could be interpreted as correct behavior, with it being a scroll view, it creates an odd user experience with nothing lying underneath.

This also conflicts with the drawer (hamburger) navigation structure. If a user is pulling on a cell, intending to pull left to right to open the drawer navigation, it is pretty bad UX.
