### PR TITLE
Add -swipeableTableViewCell:canSwipeToState: delegate

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -28,7 +28,7 @@ typedef enum {
 - (void)swipeableTableViewCell:(SWTableViewCell *)cell didTriggerLeftUtilityButtonWithIndex:(NSInteger)index;
 - (void)swipeableTableViewCell:(SWTableViewCell *)cell didTriggerRightUtilityButtonWithIndex:(NSInteger)index;
 - (void)swipeableTableViewCell:(SWTableViewCell *)cell scrollingToState:(SWCellState)state;
-
+- (BOOL)swipeableTableViewCell:(SWTableViewCell *)cell canSwipeToState:(SWCellState)state;
 @end
 
 @interface SWTableViewCell : UITableViewCell

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -508,6 +508,14 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     {
         if ([self rightUtilityButtonsWidth] > 0)
         {
+            if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
+            {
+                scrollView.scrollEnabled = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateRight];
+                if (!scrollView.scrollEnabled)
+                {
+                    return;
+                }
+            }
             CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self rightUtilityButtonsWidth]);
             
             // Expose the right button view
@@ -523,6 +531,14 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
         // Expose the left button view
         if ([self leftUtilityButtonsWidth] > 0)
         {
+            if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
+            {
+                scrollView.scrollEnabled = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateLeft];
+                if (!scrollView.scrollEnabled)
+                {
+                    return;
+                }
+            }
             CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self leftUtilityButtonsWidth]);
             
             self.scrollViewButtonViewLeft.frame = CGRectMake([self leftUtilityButtonsWidth], 0.0f, scrollViewWidth, self.height);


### PR DESCRIPTION
As title, I added a delegate method to ask if a swipeable table cell can be swiped or not. Sometimes we want some cells to be fixed (a running task in a time counter app, which should not be removed until finished for example). By implementing this delegate method, we can manage it.
