### PR TITLE
bug fix: check cell type when enumerating visible cells to call @selector(hideUtilityButtonsAnimated:)

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -404,7 +404,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     if ([self.delegate respondsToSelector:@selector(swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:)])
     {
         for (SWTableViewCell *cell in [self.containingTableView visibleCells]) {
-            if (cell != self && [self.delegate swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:cell]) {
+            if (cell != self && [cell isKindOfClass:[SWTableViewCell class]] && [self.delegate swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:cell]) {
                 [cell hideUtilityButtonsAnimated:YES];
             }
         }
@@ -441,7 +441,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     if ([self.delegate respondsToSelector:@selector(swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:)])
     {
         for (SWTableViewCell *cell in [self.containingTableView visibleCells]) {
-            if (cell != self && [self.delegate swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:cell]) {
+            if (cell != self && [cell isKindOfClass:[SWTableViewCell class]] && [self.delegate swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:cell]) {
                 [cell hideUtilityButtonsAnimated:YES];
             }
         }


### PR DESCRIPTION
When some cells in the tableview are not the kind of SWTableViewCell class. These code must crash:

```
for (SWTableViewCell *cell in [self.containingTableView visibleCells]) {
    if (cell != self &&s [self.delegate swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:cell]) {
        [cell hideUtilityButtonsAnimated:YES];
    }
}
```

My situation is that I have a loading more data cell which not the kind of SWTableViewCell in the tableview's last item. It caused me crash. So I modified the code as the diff shows. 
