### PR TITLE
Fix for display issue and more Apple like style

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -490,7 +490,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
                 if ([self leftUtilityButtonsWidth] > 0)
                     [self scrollToLeft:targetContentOffset];
             }
-            else
+            else if (velocity.x != 0)
             {
                 CGFloat rightThreshold = [self utilityButtonsPadding] - ([self rightUtilityButtonsWidth] / 2);
                 CGFloat leftThreshold = [self leftUtilityButtonsWidth] / 2;


### PR DESCRIPTION
Hi,

this is a fix for a problem when using SWTableViewCell with buttons on only one side.
I am using SWTableViewCell in my app always even when I only want to show a delete button because I want to have a seamless user experience.
Short example: you have a SWTableVIewCell with one button on the right side and none on the left and then swipe that cell very fast to the right the content just bounces. When you then try to scroll the same cell to the left side the cell shows a very short time the button but pops back. This is very hard to reproduce in the simulator on a device it is a bit easier but does not really appear every time.
The problem is that the fast dragging triggers some methods and the end is that "kCellStateLeft" is set even there are not buttons on the left side and the cell still shows its center.
My solution is simple, I just return right away if the target content offset is "(0, 0)".

In addition I added the cell not to bounce if there are no buttons. This is just like the cells in the Apple apps do it...

Regards,
Alexander
