### PR TITLE
Prevent cell from freezing if canSwipeToState returns NO

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -552,9 +552,10 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
         {
             if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
             {
-                scrollView.scrollEnabled = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateRight];
-                if (!scrollView.scrollEnabled)
+                BOOL shouldScroll = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateRight];
+                if (!shouldScroll)
                 {
+                    scrollView.contentOffset = CGPointMake([self leftUtilityButtonsWidth], 0);
                     return;
                 }
             }
@@ -575,9 +576,10 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
         {
             if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
             {
-                scrollView.scrollEnabled = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateLeft];
-                if (!scrollView.scrollEnabled)
+                BOOL shouldScroll = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateLeft];
+                if (!shouldScroll)
                 {
+                    scrollView.contentOffset = CGPointMake([self leftUtilityButtonsWidth], 0);
                     return;
                 }
             }


### PR DESCRIPTION
If swipeableTableViewCell:canSwipeToState: ever returned NO for one side, then that cell could no longer scroll to show utility buttons of the other side. This branch prevents scrollEnabled from being set to NO and instead just scrolls the view back to the origin.
