### PR TITLE
make the cell content not bounce when there are no buttons

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -567,6 +567,11 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
             scrollViewBounds.origin.x = MAX([self rightUtilityButtonsWidth] - scrollViewWidth, [self rightUtilityButtonsWidth] - scrollView.contentOffset.x);
             self.scrollViewButtonViewRight.bounds = scrollViewBounds;
         }
+        else
+        {
+            [scrollView setContentOffset:CGPointMake([self leftUtilityButtonsWidth], 0)];
+            self.tapGestureRecognizer.enabled = YES;
+        }
     }
     else
     {
@@ -584,6 +589,11 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
             CGFloat scrollViewWidth = MIN(scrollView.contentOffset.x - [self leftUtilityButtonsWidth], [self leftUtilityButtonsWidth]);
             
             self.scrollViewButtonViewLeft.frame = CGRectMake([self leftUtilityButtonsWidth], 0.0f, scrollViewWidth, self.height);
+        }
+        else
+        {
+            [scrollView setContentOffset:CGPointMake(0, 0)];
+            self.tapGestureRecognizer.enabled = YES;
         }
     }
 }


### PR DESCRIPTION
Do not bounce the scroll view if there are no buttons on the side. This is more Apple like style.
