### PR TITLE
Behavior optimization

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -592,17 +592,31 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
+    [self setCellState];
+    
     self.tapGestureRecognizer.enabled = YES;
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
 {
+    [self setCellState];
+    
     // Called when setContentOffset in hideUtilityButtonsAnimated: is done
     self.tapGestureRecognizer.enabled = YES;
     if (_cellState == kCellStateCenter)
     {
         self.longPressGestureRecognizer.enabled = YES;
     }
+}
+
+- (void)setCellState
+{
+    if ([self.cellScrollView contentOffset].x == [self leftUtilityButtonsWidth])
+        _cellState = kCellStateCenter;
+    else if ([self.cellScrollView contentOffset].x == 0)
+        _cellState = kCellStateLeft;
+    else if ([self.cellScrollView contentOffset].x == [self utilityButtonsPadding])
+        _cellState = kCellStateRight;
 }
 
 @end


### PR DESCRIPTION
Some optimization.
The first commit only applies if you set other cell to scroll back when you scroll another cell via the delegate method.
The second one is for ensuring the correct cell state. I encountered with several breakpoints that under certain circumstances the cell state is wrong. This happens if you scroll and while the scroll view is moving you tap it. Then the scroll view scrolls back to center. Normally this will result in cell state set to center but I saw that some cells in my table view do not do this. The result is that the first tap on a centered cell does not trigger the select action because the state is not set to centered and so nothing visible happens to the user. In the background "hideUtilitiesButtons" is executed.
I dunno why that is, for example scrolling cell 0 and tapping set the state to center, so does cell 1 but cell 2 and 3 not, 4 and 5 do correct. To find that I put logging breakpoints to "scrollViewDidEndDecelerating" and "scrollViewDidEndScrollingAnimation" and logging the cell state too. Very strange... Setting the cell state again will prevent that behavior...
