### PR TITLE
Remove needless setting of tag on utility button (fixes #111).

### DIFF
--- a/SWTableViewCell/PodFiles/SWUtilityButtonView.m
+++ b/SWTableViewCell/PodFiles/SWUtilityButtonView.m
@@ -68,7 +68,6 @@
         CGFloat utilityButtonXCord = 0;
         if (utilityButtonsCounter >= 1) utilityButtonXCord = _utilityButtonWidth * utilityButtonsCounter;
         [utilityButton setFrame:CGRectMake(utilityButtonXCord, 0, _utilityButtonWidth, CGRectGetHeight(self.bounds))];
-        [utilityButton setTag:utilityButtonsCounter];
         SWUtilityButtonTapGestureRecognizer *utilityButtonTapGestureRecognizer = [[SWUtilityButtonTapGestureRecognizer alloc] initWithTarget:_parentCell
                                                                                                                                       action:_utilityButtonSelector];
         utilityButtonTapGestureRecognizer.buttonIndex = utilityButtonsCounter;


### PR DESCRIPTION
The tag is never read by SWTableViewCell (perhaps it was in an earlier version?).  Removing this assignment allows the tag to be usefully exploited by the client, as described in #111.
