### PR TITLE
improved usability of the scroll operation

### DIFF
--- a/SWTableViewCell/PodFiles/SWCellScrollView.m
+++ b/SWTableViewCell/PodFiles/SWCellScrollView.m
@@ -10,6 +10,16 @@
 
 @implementation SWCellScrollView
 
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    if (gestureRecognizer == self.panGestureRecognizer) {
+        CGPoint translation = [(UIPanGestureRecognizer*)gestureRecognizer translationInView:gestureRecognizer.view];
+        return fabs(translation.y) <= fabs(translation.x);
+    } else {
+        return YES;
+    }
+}
+
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
     // Find out if the user is actively scrolling the tableView of which this is a member.
     // If they are, return NO, and don't let the gesture recognizers work simultaneously.


### PR DESCRIPTION
When I scroll diagonally, it is determined whether you display utility buttons in a direction.

For example, I may scroll slightly diagonally when I let you scroll up and down. (easy to be generated when I operate it with one hand)
The angle that utility buttons is displayed by diagonal scroll when it is a current version is wide.
When it is the version of the pull request, an angle necessary for utility buttons to display it becomes narrow, and erroneous operation decreases.
