### PR TITLE
add an animation in swipe

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -41,6 +41,6 @@ typedef NS_ENUM(NSInteger, SWCellState)
 
 - (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier containingTableView:(UITableView *)containingTableView leftUtilityButtons:(NSArray *)leftUtilityButtons rightUtilityButtons:(NSArray *)rightUtilityButtons;
 
-- (void)hideUtilityButtonsAnimated:(BOOL)animated;
+- (void)hideUtilityButtons;
 
 @end

--- a/SWTableViewCell/ViewController.m
+++ b/SWTableViewCell/ViewController.m
@@ -226,7 +226,7 @@
             UIAlertView *alertTest = [[UIAlertView alloc] initWithTitle:@"Hello" message:@"More more more" delegate:nil cancelButtonTitle:@"cancel" otherButtonTitles: nil];
             [alertTest show];
         
-            [cell hideUtilityButtonsAnimated:YES];
+            [cell hideUtilityButtons];
             break;
         }
         case 1:


### PR DESCRIPTION
Added an animation to be able to get closer to behavior of iOS 7 Mail Application.

I changed the touch operation of the view to the possibility in scroll and an animation.
Reason:
- After an animation, to enable a tap earlier.
- I feel that it is not necessary to prohibit a tap during scroll.
