### PR TITLE
Fixes issues for cells with buttons or any other UIControl elements

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -117,6 +117,7 @@
     
     self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(scrollViewTapped:)];
     self.tapGestureRecognizer.cancelsTouchesInView = NO;
+    self.tapGestureRecognizer.delegate             = self;
     [self.cellScrollView addGestureRecognizer:self.tapGestureRecognizer];
     
     self.longPressGestureRecognizer = [[SWLongPressGestureRecognizer alloc] initWithTarget:self action:@selector(scrollViewPressed:)];
@@ -620,6 +621,11 @@
     {
         return NO;
     }
+}
+
+-(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    return ![touch.view isKindOfClass:[UIControl class]];
 }
 
 @end


### PR DESCRIPTION
Hi there,

I've been using your cell and it's pretty good!

But, when I tried to use it on cells with buttons, by pressing the button it was calling the "didSelectRowAtIndexPath" and triggering the button action too, and this is probably happening for any other UIControl element.

Is not a big change and it's working for me at least.

Thanks for your work!

Regards

Camo
