### PR TITLE
use existing delegate method to close open cells on table swipe

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -298,7 +298,7 @@ static NSString * const kTableViewPanState = @"state";
 {
     [super prepareForReuse];
     
-    _cellState = kCellStateCenter;
+    [self hideUtilityButtonsAnimated:NO];
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated


### PR DESCRIPTION
When a pan begins on the tableview, all open cells (except for the one being touched/panned) will call the `swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:` delegate method and close if YES.

This is pretty much exactly how the Mail.app tables behaves and seems like something that should be included in the core.
