### PR TITLE
[rex-remind101/SWTableViewCell] Fixed the initializer sequence.

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -39,8 +39,6 @@ typedef NS_ENUM(NSInteger, SWCellState)
 @property (nonatomic, copy) NSArray *rightUtilityButtons;
 @property (nonatomic, weak) id <SWTableViewCellDelegate> delegate;
 
-- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier containingTableView:(UITableView *)containingTableView leftUtilityButtons:(NSArray *)leftUtilityButtons rightUtilityButtons:(NSArray *)rightUtilityButtons;
-
 - (void)hideUtilityButtonsAnimated:(BOOL)animated;
 
 @end

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -43,19 +43,6 @@
 
 #pragma mark Initializers
 
-- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier containingTableView:(UITableView *)containingTableView leftUtilityButtons:(NSArray *)leftUtilityButtons rightUtilityButtons:(NSArray *)rightUtilityButtons
-{
-    self = [self initWithStyle:style reuseIdentifier:reuseIdentifier];
-    if (self)
-    {
-        self.containingTableView = containingTableView;
-        self.rightUtilityButtons = rightUtilityButtons;
-        self.leftUtilityButtons = leftUtilityButtons;
-    }
-    
-    return self;
-}
-
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];


### PR DESCRIPTION
`initWithStyle:reuseIdentifier:` is the designated initializer, therefore, all initializers outside of `initWithCoder:` should go through it.

`init` will trigger the designated initializer automatically.
