### PR TITLE
Detect only buttons on left or right

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -553,7 +553,16 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (scrollView.contentOffset.x > [self leftUtilityButtonsWidth])
+    if ( scrollView.contentOffset.x < 0 && _leftUtilityButtons.count == 0 )
+    {
+        // Block scroll to right if _leftUtilityButtons.count is 0
+        scrollView.contentOffset = CGPointZero;
+    } else if ( scrollView.contentOffset.x > [self leftUtilityButtonsWidth] && _rightUtilityButtons.count == 0 )
+    {
+        // Block scroll to left if _rightUtilityButtons.count is 0
+        scrollView.contentOffset = [self contentOffsetForCellState:_cellState];
+    }
+    else if (scrollView.contentOffset.x > [self leftUtilityButtonsWidth])
     {
         if ([self rightUtilityButtonsWidth] > 0)
         {


### PR DESCRIPTION
Detect if there are only button on left or right to set the scroll in one direction.
Refs: [issue #12](https://github.com/CEWendel/SWTableViewCell/pull/12)
