### PR TITLE
Fixed unselectable cell bug

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -467,7 +467,7 @@
 {
     if (velocity.x >= 0.5f)
     {
-        if (_cellState == kCellStateLeft)
+        if (_cellState == kCellStateLeft || !self.rightUtilityButtons || self.rightUtilityButtonsWidth == 0.0)
         {
             _cellState = kCellStateCenter;
         }
@@ -478,7 +478,7 @@
     }
     else if (velocity.x <= -0.5f)
     {
-        if (_cellState == kCellStateRight)
+        if (_cellState == kCellStateRight || !self.leftUtilityButtons || self.leftUtilityButtonsWidth == 0.0)
         {
             _cellState = kCellStateCenter;
         }
@@ -579,6 +579,15 @@
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
 {
     [self updateCellState];
+}
+
+-(void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
+{
+    if (!decelerate)
+    {
+        self.tapGestureRecognizer.enabled = YES;
+    }
+    
 }
 
 #pragma mark - UIGestureRecognizerDelegate


### PR DESCRIPTION
Regarding pull request #132, fixed the unselectable cell bug when dragging a cell in a direction where there are no buttons.
This bug is easy reproductible by commenting the line 138 ( cell.rightUtilityButtons = [self rightButtons]; ) in the file ViewController.m from the project SWTableViewCell. The situations happens after dragging a cell in the right direction, it becomes then unselectable.
