### PR TITLE
Resolves #139, crash on Autolayout code due to constraints

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -9,6 +9,7 @@
 #import "SWTableViewCell.h"
 #import <UIKit/UIGestureRecognizerSubclass.h>
 #import "SWUtilityButtonView.h"
+#import "UITableViewCell+FixUITableViewCellAutolayout.h"
 
 #define kSectionIndexWidth 15
 #define kLongPressMinimumDuration 0.16f
@@ -209,7 +210,6 @@
 
 - (void)layoutSubviews
 {
-    [super layoutSubviews];
     
     // Offset the contentView origin so that it appears correctly w/rt the enclosing scroll view (to which we moved it).
     CGRect frame = self.contentView.frame;
@@ -224,6 +224,8 @@
     }
 
     [self updateCellState];
+    [super layoutSubviews];
+
 }
 
 - (void)prepareForReuse

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -210,7 +210,6 @@
 
 - (void)layoutSubviews
 {
-    
     // Offset the contentView origin so that it appears correctly w/rt the enclosing scroll view (to which we moved it).
     CGRect frame = self.contentView.frame;
     frame.origin.x = self.leftUtilityButtonsView.frame.size.width;
@@ -224,8 +223,10 @@
     }
 
     [self updateCellState];
+    
+    // purposefully called at the end of the routine
+    // resolves constaint based crash on iOS6, bug #139
     [super layoutSubviews];
-
 }
 
 - (void)prepareForReuse

--- a/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.h
+++ b/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.h
@@ -1,18 +1,11 @@
 //
-//  UITableViewCell+FixUITableViewCellAutolayoutIHope.h
-//  CTClient
+//  UITableViewCell+FixUITableViewCellAutolayout.h
 //
 //  Created by Philip Jacobsen on 5/21/14.
 //  Copyright (c) 2014 CrowdTunes LLC. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
-
-#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
-#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
 
 @interface UITableViewCell (FixUITableViewCellAutolayout)
 

--- a/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.h
+++ b/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.h
@@ -1,0 +1,19 @@
+//
+//  UITableViewCell+FixUITableViewCellAutolayoutIHope.h
+//  CTClient
+//
+//  Created by Philip Jacobsen on 5/21/14.
+//  Copyright (c) 2014 CrowdTunes LLC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
+#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
+
+@interface UITableViewCell (FixUITableViewCellAutolayout)
+
+@end

--- a/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.m
+++ b/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.m
@@ -1,21 +1,22 @@
 //
-//  UITableViewCell+FixUITableViewCellAutolayoutIHope.m
-//  CTClient
+// UITableViewCell+FixUITableViewCellAutolayout.m
 //
 //  Created by Philip Jacobsen on 5/21/14.
 //  Copyright (c) 2014 CrowdTunes LLC. All rights reserved.
 //
+// Method swizzling of layoutSubviews resolves crash bug resulting from AutoLayout
 
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import "UITableViewCell+FixUITableViewCellAutolayout.h"
 
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+
 // See http://stackoverflow.com/questions/12610783/auto-layout-still-required-after-executing-layoutsubviews-with-uitableviewcel
 
 @implementation UITableViewCell (FixUITableViewCellAutolayout)
 
-+ (void)load
-{
++ (void)load {
     if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
         Method existing = class_getInstanceMethod(self, @selector(layoutSubviews));
         Method new = class_getInstanceMethod(self, @selector(_autolayout_replacementLayoutSubviews));
@@ -24,8 +25,7 @@
     }
 }
 
-- (void)_autolayout_replacementLayoutSubviews
-{
+- (void)_autolayout_replacementLayoutSubviews {
     [super layoutSubviews];
     [self _autolayout_replacementLayoutSubviews]; // not recursive due to method swizzling
     [super layoutSubviews];

--- a/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.m
+++ b/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.m
@@ -1,0 +1,32 @@
+//
+//  UITableViewCell+FixUITableViewCellAutolayoutIHope.m
+//  CTClient
+//
+//  Created by Philip Jacobsen on 5/21/14.
+//  Copyright (c) 2014 CrowdTunes LLC. All rights reserved.
+//
+
+#import <objc/runtime.h>
+#import <objc/message.h>
+#import "UITableViewCell+FixUITableViewCellAutolayout.h"
+
+@implementation UITableViewCell (FixUITableViewCellAutolayout)
+
++ (void)load
+{
+    if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
+        Method existing = class_getInstanceMethod(self, @selector(layoutSubviews));
+        Method new = class_getInstanceMethod(self, @selector(_autolayout_replacementLayoutSubviews));
+        
+        method_exchangeImplementations(existing, new);
+    }
+}
+
+- (void)_autolayout_replacementLayoutSubviews
+{
+    [super layoutSubviews];
+    [self _autolayout_replacementLayoutSubviews]; // not recursive due to method swizzling
+    [super layoutSubviews];
+}
+
+@end

--- a/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.m
+++ b/SWTableViewCell/PodFiles/UITableViewCell+FixUITableViewCellAutolayout.m
@@ -10,6 +10,8 @@
 #import <objc/message.h>
 #import "UITableViewCell+FixUITableViewCellAutolayout.h"
 
+// See http://stackoverflow.com/questions/12610783/auto-layout-still-required-after-executing-layoutsubviews-with-uitableviewcel
+
 @implementation UITableViewCell (FixUITableViewCellAutolayout)
 
 + (void)load


### PR DESCRIPTION
This resolves the crash on iOS 6 and has no impact on iOS 7+.

Ideally, we think it might be best to rethink the view hierarchy and NOT move the contentView out of the UITableViewCell root, but instead pull the subviews out and place those in the ScrollView.  That would require substantial reworking though so we opted for this in the near term.

Hopefully this will help some other folks in the mean time.
Great library!
MV
