### PR TITLE
Add (optional) delegate method for end of scrolling.

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSInteger, SWCellState)
 - (void)swipeableTableViewCell:(SWTableViewCell *)cell scrollingToState:(SWCellState)state;
 - (BOOL)swipeableTableViewCellShouldHideUtilityButtonsOnSwipe:(SWTableViewCell *)cell;
 - (BOOL)swipeableTableViewCell:(SWTableViewCell *)cell canSwipeToState:(SWCellState)state;
+- (void)swipeableTableViewCellDidEndScrolling:(SWTableViewCell *)cell;
 
 @end
 

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -676,11 +676,19 @@ static NSString * const kTableViewPanState = @"state";
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     [self updateCellState];
+
+    if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCellDidEndScrolling:)]) {
+        [self.delegate swipeableTableViewCellDidEndScrolling:self];
+    }
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
 {
     [self updateCellState];
+
+    if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCellDidEndScrolling:)]) {
+        [self.delegate swipeableTableViewCellDidEndScrolling:self];
+    }
 }
 
 -(void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate


### PR DESCRIPTION
This allows you to get notified when scrolling ends. This is important for when I need to update a cell and doing this in scrollingToState delegate method causes it to "jump".
