### PR TITLE
return UIButton* for sw_addUtilityButton APIs

### DIFF
--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
@@ -7,12 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NSMutableArray (SWUtilityButtons)
 
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color title:(NSString *)title;
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon;
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon;
+- (UIButton*)sw_addUtilityButtonWithColor:(UIColor *)color title:(NSString *)title;
+- (UIButton*)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon;
+- (UIButton*)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon;
 
 @end
 

--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
@@ -10,30 +10,33 @@
 
 @implementation NSMutableArray (SWUtilityButtons)
 
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color title:(NSString *)title
+- (UIButton*)sw_addUtilityButtonWithColor:(UIColor *)color title:(NSString *)title
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     button.backgroundColor = color;
     [button setTitle:title forState:UIControlStateNormal];
     [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
     [self addObject:button];
+    return button;
 }
 
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon
+- (UIButton*)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     button.backgroundColor = color;
     [button setImage:icon forState:UIControlStateNormal];
     [self addObject:button];
+    return button;
 }
 
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon {
+- (UIButton*)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     button.backgroundColor = color;
     [button setImage:normalIcon forState:UIControlStateNormal];
     [button setImage:selectedIcon forState:UIControlStateHighlighted];
     [button setImage:selectedIcon forState:UIControlStateSelected];
     [self addObject:button];
+    return button;
 }
 
 @end


### PR DESCRIPTION
return UIButton\* for sw_addUtilityButton APIs, as for my case I've utilize UIButton's tag properties instead of button index for action handling codes, and I've presume that returning UIButton instance may allow user to customize further UIButton's attributes
