### PR TITLE
Enqueues tableView delegate callbacks on the next run loop cycle to allow the view to redraw for cell selection/highlighting prior to whatever drawing code is executed in the delegate callbacks

### DIFF
--- a/SWTableViewCell.xcodeproj/project.pbxproj
+++ b/SWTableViewCell.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B955789197EC6E800461F4C /* NSObject+PerformSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B955788197EC6E800461F4C /* NSObject+PerformSelector.m */; };
 		810308911846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m in Sources */ = {isa = PBXBuildFile; fileRef = 810308861846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m */; };
 		810308921846579B00C378F0 /* SWCellScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 810308881846579B00C378F0 /* SWCellScrollView.m */; };
 		810308931846579B00C378F0 /* SWLongPressGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103088A1846579B00C378F0 /* SWLongPressGestureRecognizer.m */; };
@@ -34,6 +35,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3B955787197EC6E800461F4C /* NSObject+PerformSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+PerformSelector.h"; sourceTree = "<group>"; };
+		3B955788197EC6E800461F4C /* NSObject+PerformSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+PerformSelector.m"; sourceTree = "<group>"; };
 		810308851846579B00C378F0 /* NSMutableArray+SWUtilityButtons.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+SWUtilityButtons.h"; sourceTree = "<group>"; };
 		810308861846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+SWUtilityButtons.m"; sourceTree = "<group>"; };
 		810308871846579B00C378F0 /* SWCellScrollView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWCellScrollView.h; sourceTree = "<group>"; };
@@ -92,6 +95,8 @@
 			children = (
 				810308851846579B00C378F0 /* NSMutableArray+SWUtilityButtons.h */,
 				810308861846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m */,
+				3B955787197EC6E800461F4C /* NSObject+PerformSelector.h */,
+				3B955788197EC6E800461F4C /* NSObject+PerformSelector.m */,
 				810308871846579B00C378F0 /* SWCellScrollView.h */,
 				810308881846579B00C378F0 /* SWCellScrollView.m */,
 				810308891846579B00C378F0 /* SWLongPressGestureRecognizer.h */,
@@ -242,6 +247,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B955789197EC6E800461F4C /* NSObject+PerformSelector.m in Sources */,
 				AF34B77517DEE2B400BD9082 /* main.m in Sources */,
 				AF34B77917DEE2B400BD9082 /* AppDelegate.m in Sources */,
 				810308921846579B00C378F0 /* SWCellScrollView.m in Sources */,

--- a/SWTableViewCell/PodFiles/NSObject+PerformSelector.h
+++ b/SWTableViewCell/PodFiles/NSObject+PerformSelector.h
@@ -1,0 +1,23 @@
+//
+//  NSObject+PerformSelector.h
+//  SWTableViewCell
+//
+//  Created by Colin Regan on 7/22/14.
+//  Copyright (c) 2014 Chris Wendel. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSObject (PerformSelector)
+
+/**
+ *  Performs the specified selector on the current thread during the next run loop cycle.
+ *
+ *  @param aSelector A selector that identifies the method to invoke. The method should not have a significant return value and should take the same number of arguments that are included in the `args` array.
+ *  @param args The arguments to pass to the method when it is invoked. Pass nil if the method does not take any arguments.
+ *
+ *  @discussion This method enqueues the `aSelector` message on the run loop of the current thread. This is useful in cases where it's not desireable to group multiple view drawing operations into the same drawing cycle. Using this method will cause the selector to be invoked as soon as possible, but on the next run loop cycle.
+ */
+- (void)performSelectorOnNextRunLoopCycle:(SEL)aSelector withObjects:(NSArray *)args;
+
+@end

--- a/SWTableViewCell/PodFiles/NSObject+PerformSelector.m
+++ b/SWTableViewCell/PodFiles/NSObject+PerformSelector.m
@@ -1,0 +1,26 @@
+//
+//  NSObject+PerformSelector.m
+//  SWTableViewCell
+//
+//  Created by Colin Regan on 7/22/14.
+//  Copyright (c) 2014 Chris Wendel. All rights reserved.
+//
+
+#import "NSObject+PerformSelector.h"
+
+@implementation NSObject (PerformSelector)
+
+- (void)performSelectorOnNextRunLoopCycle:(SEL)aSelector withObjects:(NSArray *)args
+{
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:aSelector]];
+    [invocation setSelector:aSelector];
+    [invocation setTarget:self];
+    [args enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [invocation setArgument:&obj atIndex:(idx + 2)];
+    }];
+    [invocation retainArguments];
+    
+    [invocation performSelector:@selector(invoke) withObject:nil afterDelay:0];
+}
+
+@end

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -8,6 +8,7 @@
 
 #import "SWTableViewCell.h"
 #import "SWUtilityButtonView.h"
+#import "NSObject+PerformSelector.h"
 
 #define kSectionIndexWidth 15
 #define kAccessoryTrailingSpace 15
@@ -394,9 +395,10 @@ static NSString * const kTableViewPanState = @"state";
         {
             [self.containingTableView selectRowAtIndexPath:cellIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
             
-            if ([self.containingTableView.delegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)])
+            SEL aSelector = @selector(tableView:didSelectRowAtIndexPath:);
+            if ([self.containingTableView.delegate respondsToSelector:aSelector] && [self.containingTableView.delegate isKindOfClass:[NSObject class]])
             {
-                [self.containingTableView.delegate tableView:self.containingTableView didSelectRowAtIndexPath:cellIndexPath];
+                [(NSObject *)self.containingTableView.delegate performSelectorOnNextRunLoopCycle:aSelector withObjects:@[self.containingTableView, cellIndexPath]];
             }
         }
     }
@@ -417,9 +419,10 @@ static NSString * const kTableViewPanState = @"state";
         {
             [self.containingTableView deselectRowAtIndexPath:cellIndexPath animated:NO];
             
-            if ([self.containingTableView.delegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)])
+            SEL aSelector = @selector(tableView:didDeselectRowAtIndexPath:);
+            if ([self.containingTableView.delegate respondsToSelector:aSelector] && [self.containingTableView.delegate isKindOfClass:[NSObject class]])
             {
-                [self.containingTableView.delegate tableView:self.containingTableView didDeselectRowAtIndexPath:cellIndexPath];
+                [(NSObject *)self.containingTableView.delegate performSelectorOnNextRunLoopCycle:aSelector withObjects:@[self.containingTableView, cellIndexPath]];
             }
         }
     }


### PR DESCRIPTION
Currently, if a tableView delegate callback invokes any view drawing methods (for example performSegue), those drawing calls will be grouped together with the cell selection/highlighting into the same drawing cycle, resulting in a visible delay in cell highlighting.  This patch defers those callbacks to the next run loop cycle, allowing the view to redraw the highlighted state prior to executing the delegate callback.
