### PR TITLE
Enabled adjustment of font size to fit width for textual button

### DIFF
--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
@@ -16,6 +16,7 @@
     button.backgroundColor = color;
     [button setTitle:title forState:UIControlStateNormal];
     [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    [button.titleLabel setAdjustsFontSizeToFitWidth:YES];
     [self addObject:button];
 }
 


### PR DESCRIPTION
Using the "Unsubscribe" label on a textual button, the text is cropped.
Just enabled the adjust font size to fit width property to fix that - the font size is reduced, but the text is fully displayed and readable.
