### PR TITLE
adding the hide all but cell method

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, SWCellState)
 - (void)setRightUtilityButtons:(NSArray *)rightUtilityButtons WithButtonWidth:(CGFloat) width;
 - (void)setLeftUtilityButtons:(NSArray *)leftUtilityButtons WithButtonWidth:(CGFloat) width;
 - (void)hideUtilityButtonsAnimated:(BOOL)animated;
+- (void)hideUtilityButtons:(UITableView *)tableView exceptForCell:(SWTableViewCell *)cell animated:(BOOL)animated;
 - (void)showLeftUtilityButtonsAnimated:(BOOL)animated;
 - (void)showRightUtilityButtonsAnimated:(BOOL)animated;
 

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -476,6 +476,23 @@ static NSString * const kTableViewPanState = @"state";
     }
 }
 
+- (void)hideUtilityButtons:(UITableView *)tableView exceptForCell:(SWTableViewCell *)cell animated:(BOOL)animated
+{
+	NSArray *paths = [tableView indexPathsForVisibleRows];
+    
+    NSMutableSet *visibleCells = [[NSMutableSet alloc] init];
+    
+    for (NSIndexPath *path in paths) {
+        [visibleCells addObject:[tableView cellForRowAtIndexPath:path]];
+    }
+    
+    for (SWBaseCell *checkCell in visibleCells) {
+        if (checkCell != cell) {
+            [checkCell hideUtilityButtonsAnimated:animated];
+        }
+    }
+}
+
 - (void)showLeftUtilityButtonsAnimated:(BOOL)animated {
     if (_cellState != kCellStateLeft)
     {


### PR DESCRIPTION
I had a use case for the v2.0 Its On Me app where ...  when you slide open one cell , it was required that any other open cell closed.  I solved this use case by making a multi-purposed method that you could call from anywhere that resets any cell that isn't the cell you pass in.  Pretty self explanatory.  Thanks for the cool pod dude ! 

FYI, i overwrote in a base cell class in my version , I was un-able to overwrite as i am commiting below due to pod overwriting being a pain.  So please run this before for any typos etc ... My base class version works perfectly . 
