### PR TITLE
Cells should not be reused if button state changes

### DIFF
--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
@@ -77,7 +77,9 @@
     UIImage *selectedIconB = [buttonB imageForState:UIControlStateSelected];
     BOOL haveEqualSelectedIcons = (!selectedIconA && !selectedIconB) || [selectedIconA isEqual:selectedIconB];
     
-    return haveEqualBackgroundColors && haveEqualTitles && haveEqualNormalIcons && haveEqualSelectedIcons;
+    BOOL haveEqualSelectedState = buttonA.selected == buttonB.selected;
+    
+    return haveEqualBackgroundColors && haveEqualTitles && haveEqualNormalIcons && haveEqualSelectedIcons && haveEqualSelectedState;
 }
 
 @end


### PR DESCRIPTION
This adds additional support if someone wants to change button state to
selected. 
Currently, the buttons might not get re-drawn because of cell re-use, The set functions for left and right buttons check if the buttons and images change, and if they didn't, they will not re-draw the cell. 
So we just have to make sure that we additionally check for button state and redraw the cell if they have changed.
