### PR TITLE
Fixes #237, Right utility buttons don't work properly on iOS 8

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -242,7 +242,8 @@ static NSString * const kTableViewPanState = @"state";
         _leftUtilityButtons = leftUtilityButtons;
         
         self.leftUtilityButtonsView.utilityButtons = leftUtilityButtons;
-        
+
+        [self.leftUtilityButtonsView layoutIfNeeded];
         [self layoutIfNeeded];
     }
 }
@@ -252,7 +253,8 @@ static NSString * const kTableViewPanState = @"state";
     _leftUtilityButtons = leftUtilityButtons;
     
     [self.leftUtilityButtonsView setUtilityButtons:leftUtilityButtons WithButtonWidth:width];
-    
+
+    [self.leftUtilityButtonsView layoutIfNeeded];
     [self layoutIfNeeded];
 }
 
@@ -262,7 +264,8 @@ static NSString * const kTableViewPanState = @"state";
         _rightUtilityButtons = rightUtilityButtons;
         
         self.rightUtilityButtonsView.utilityButtons = rightUtilityButtons;
-        
+
+        [self.rightUtilityButtonsView layoutIfNeeded];
         [self layoutIfNeeded];
     }
 }
@@ -272,7 +275,8 @@ static NSString * const kTableViewPanState = @"state";
     _rightUtilityButtons = rightUtilityButtons;
     
     [self.rightUtilityButtonsView setUtilityButtons:rightUtilityButtons WithButtonWidth:width];
-    
+
+    [self.rightUtilityButtonsView layoutIfNeeded];
     [self layoutIfNeeded];
 }
 


### PR DESCRIPTION
This fixes button width not being set correctly in some cases on iOS 8. Fixes #237

On iOS 8, just calling `[self layoutIfNeeded]` after setting the utility buttons appears to be insufficient. The actual buttonsView still has a width of 0 after setting the constant on the width constraint. Explicitly calling `layoutIfNeeded` on the buttonsView fixes this problem.
