### PR TITLE
swipeableTableViewCell:canSwipeToState: is calling before scroll and only once

### DIFF
--- a/SWTableViewCell/PodFiles/SWCellScrollView.h
+++ b/SWTableViewCell/PodFiles/SWCellScrollView.h
@@ -7,7 +7,9 @@
 //
 
 #import <UIKit/UIKit.h>
+@class SWTableViewCell;
 
 @interface SWCellScrollView : UIScrollView <UIGestureRecognizerDelegate>
 
+@property (nonatomic, weak) SWTableViewCell *cell;
 @end

--- a/SWTableViewCell/PodFiles/SWCellScrollView.m
+++ b/SWTableViewCell/PodFiles/SWCellScrollView.m
@@ -7,6 +7,7 @@
 //
 
 #import "SWCellScrollView.h"
+#import "SWTableViewCell.h"
 
 @implementation SWCellScrollView
 
@@ -14,7 +15,15 @@
 {
     if (gestureRecognizer == self.panGestureRecognizer) {
         CGPoint translation = [(UIPanGestureRecognizer*)gestureRecognizer translationInView:gestureRecognizer.view];
-        return fabs(translation.y) <= fabs(translation.x);
+		if(fabs(translation.y) <= fabs(translation.x))
+		{
+			if ([self.cell.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
+				return [self.cell.delegate swipeableTableViewCell:(SWTableViewCell *)self.superview canSwipeToState:(translation.x > 0 ? kCellStateLeft : kCellStateRight)];
+			else
+				return YES;
+		}
+		else
+			return NO;
     } else {
         return YES;
     }
@@ -36,6 +45,11 @@
         
     }
     return YES;
+}
+
+- (BOOL)touchesShouldCancelInContentView:(UIView *)view
+{
+	return YES;
 }
 
 @end

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -24,7 +24,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
 @property (nonatomic, assign) SWCellState cellState; // The state of the cell within the scroll view, can be left, right or middle
 @property (nonatomic, assign) CGFloat additionalRightPadding;
 
-@property (nonatomic, strong) UIScrollView *cellScrollView;
+@property (nonatomic, strong) SWCellScrollView *cellScrollView;
 @property (nonatomic, strong) SWUtilityButtonView *leftUtilityButtonsView, *rightUtilityButtonsView;
 @property (nonatomic, strong) UIView *leftUtilityClipView, *rightUtilityClipView;
 @property (nonatomic, strong) NSLayoutConstraint *leftUtilityClipConstraint, *rightUtilityClipConstraint;
@@ -84,7 +84,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     self.cellScrollView.showsHorizontalScrollIndicator = NO;
     self.cellScrollView.scrollsToTop = NO;
     self.cellScrollView.scrollEnabled = YES;
-    
+	self.cellScrollView.cell = self;
     _contentCellView = [[UIView alloc] init];
     [self.cellScrollView addSubview:_contentCellView];
     
@@ -164,7 +164,11 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
                                [NSLayoutConstraint constraintWithItem:clipView attribute:alignmentAttribute relatedBy:NSLayoutRelationEqual toItem:self attribute:alignmentAttribute multiplier:1.0 constant:0.0],
                                clipConstraint,
                                ]];
-        
+		
+		NSLayoutConstraint *cons = [NSLayoutConstraint constraintWithItem:buttonView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqual toItem:self.contentView attribute:NSLayoutAttributeWidth multiplier:1.0 constant:-kUtilityButtonWidthDefault];
+		
+		cons.priority = 900;
+		
         [clipView addSubview:buttonView];
         [self addConstraints:@[
                                // Pin the button view to the appropriate outer edges of its clipping view.
@@ -173,7 +177,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
                                [NSLayoutConstraint constraintWithItem:buttonView attribute:alignmentAttribute relatedBy:NSLayoutRelationEqual toItem:clipView attribute:alignmentAttribute multiplier:1.0 constant:0.0],
                                
                                // Constrain the maximum button width so that at least a button's worth of contentView is left visible. (The button view will shrink accordingly.)
-                               [NSLayoutConstraint constraintWithItem:buttonView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqual toItem:self.contentView attribute:NSLayoutAttributeWidth multiplier:1.0 constant:-kUtilityButtonWidthDefault],
+                               cons,
                                ]];
     }
 }
@@ -710,14 +714,14 @@ static NSString * const kTableViewPanState = @"state";
     {
         if ([self rightUtilityButtonsWidth] > 0)
         {
-            if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
-            {
-                BOOL shouldScroll = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateRight];
-                if (!shouldScroll)
-                {
-                    scrollView.contentOffset = CGPointMake([self leftUtilityButtonsWidth], 0);
-                }
-            }
+//            if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
+//            {
+//                BOOL shouldScroll = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateRight];
+//                if (!shouldScroll)
+//                {
+//                    scrollView.contentOffset = CGPointMake([self leftUtilityButtonsWidth], 0);
+//                }
+//            }
         }
         else
         {
@@ -730,14 +734,14 @@ static NSString * const kTableViewPanState = @"state";
         // Expose the left button view
         if ([self leftUtilityButtonsWidth] > 0)
         {
-            if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
-            {
-                BOOL shouldScroll = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateLeft];
-                if (!shouldScroll)
-                {
-                    scrollView.contentOffset = CGPointMake([self leftUtilityButtonsWidth], 0);
-                }
-            }
+//            if (self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:canSwipeToState:)])
+//            {
+//                BOOL shouldScroll = [self.delegate swipeableTableViewCell:self canSwipeToState:kCellStateLeft];
+//                if (!shouldScroll)
+//                {
+//                    scrollView.contentOffset = CGPointMake([self leftUtilityButtonsWidth], 0);
+//                }
+//            }
         }
         else
         {


### PR DESCRIPTION
Previous implementation called this method many many times because it was calling from scrollViewDidScroll. Now its called from scroll view pan recognizer. When it was called after my model changed this method returns no and cancel my hiding animation.