### PR TITLE
it prevents from sending scrollview delegate method to deallocated cell

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -187,6 +187,7 @@ static NSString * const kTableViewPanState = @"state";
 
 - (void)dealloc
 {
+    _cellScrollView.delegate = nil;
     [self removeOldTableViewPanObserver];
 }
 


### PR DESCRIPTION
fixes crash reported with issue #280 