### PR TITLE
Added ability to implement delegate methods that notifies when scroll ha...

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, SWCellState)
 - (BOOL)swipeableTableViewCell:(SWTableViewCell *)cell canSwipeToState:(SWCellState)state;
 - (void)swipeableTableViewCellDidEndScrolling:(SWTableViewCell *)cell;
 - (void)swipeableTableViewCell:(SWTableViewCell *)cell didScroll:(UIScrollView *)scrollView;
-
+- (void)swipeableTableViewCell:(SWTableViewCell *)cell didSwipeToState:(SWCellState) state;
 @end
 
 @interface SWTableViewCell : UITableViewCell

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -778,7 +778,10 @@ static NSString * const kTableViewPanState = @"state";
     {
         self.tapGestureRecognizer.enabled = YES;
     }
-    
+    if(self.delegate && [self.delegate respondsToSelector:@selector(swipeableTableViewCell:didSwipeToState:)])
+    {
+        [self.delegate swipeableTableViewCell:self didSwipeToState:self.cellState];
+    }
 }
 
 #pragma mark - UIGestureRecognizerDelegate


### PR DESCRIPTION
...s ended and the state of the cell, this allows for implementations where you would want to execute a command when scrolling ends

Usage:

-(void) swipeableTableViewCell:(SWTableViewCell *)cell didSwipeToState:(SWCellState)state
{
    if(state == kCellStateLeft)
    {
        NSLog(@"Swiped right");
    }
    if(state == kCellStateRight)
    {
        NSLog(@"Swiped left");
    }
    
    if(state == kCellStateCenter)
    {
        NSLog(@"Closed");
    }
}