### PR TITLE
Make utility buttons available through accessibility actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,19 @@ In your `tableView:cellForRowAtIndexPath:` method you set up the SWTableView cel
     
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:0.07 green:0.75f blue:0.16f alpha:1.0]
-                                                icon:[UIImage imageNamed:@"check.png"]];
+                                                icon:[UIImage imageNamed:@"check.png"]
+                                                accessibilityLabel:NSLocalizedString(@"Mark as done", nil)];
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:1.0f green:1.0f blue:0.35f alpha:1.0]
-                                                icon:[UIImage imageNamed:@"clock.png"]];
+                                                icon:[UIImage imageNamed:@"clock.png"]
+                                                accessibilityLabel:NSLocalizedString(@"Schedule", nil)];
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:1.0f green:0.231f blue:0.188f alpha:1.0]
                                                 icon:[UIImage imageNamed:@"cross.png"]];
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:0.55f green:0.27f blue:0.07f alpha:1.0]
-                                                icon:[UIImage imageNamed:@"list.png"]];
+                                                icon:[UIImage imageNamed:@"list.png"]
+                                                accessibilityLabel:NSLocalizedString(@"Add to list", nil)];
     
     return leftUtilityButtons;
 }

--- a/SWTableViewCell.xcodeproj/project.pbxproj
+++ b/SWTableViewCell.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B23AE8B1AEC424000CACDB7 /* SWAccessibilityCustomAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B23AE8A1AEC424000CACDB7 /* SWAccessibilityCustomAction.m */; };
 		810308911846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m in Sources */ = {isa = PBXBuildFile; fileRef = 810308861846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m */; };
 		810308921846579B00C378F0 /* SWCellScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 810308881846579B00C378F0 /* SWCellScrollView.m */; };
 		810308931846579B00C378F0 /* SWLongPressGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103088A1846579B00C378F0 /* SWLongPressGestureRecognizer.m */; };
@@ -34,6 +35,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6B23AE891AEC424000CACDB7 /* SWAccessibilityCustomAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWAccessibilityCustomAction.h; sourceTree = "<group>"; };
+		6B23AE8A1AEC424000CACDB7 /* SWAccessibilityCustomAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SWAccessibilityCustomAction.m; sourceTree = "<group>"; };
 		810308851846579B00C378F0 /* NSMutableArray+SWUtilityButtons.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+SWUtilityButtons.h"; sourceTree = "<group>"; };
 		810308861846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+SWUtilityButtons.m"; sourceTree = "<group>"; };
 		810308871846579B00C378F0 /* SWCellScrollView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWCellScrollView.h; sourceTree = "<group>"; };
@@ -92,6 +95,8 @@
 			children = (
 				810308851846579B00C378F0 /* NSMutableArray+SWUtilityButtons.h */,
 				810308861846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m */,
+				6B23AE891AEC424000CACDB7 /* SWAccessibilityCustomAction.h */,
+				6B23AE8A1AEC424000CACDB7 /* SWAccessibilityCustomAction.m */,
 				810308871846579B00C378F0 /* SWCellScrollView.h */,
 				810308881846579B00C378F0 /* SWCellScrollView.m */,
 				810308891846579B00C378F0 /* SWLongPressGestureRecognizer.h */,
@@ -249,6 +254,7 @@
 			files = (
 				AF34B77517DEE2B400BD9082 /* main.m in Sources */,
 				AF34B77917DEE2B400BD9082 /* AppDelegate.m in Sources */,
+				6B23AE8B1AEC424000CACDB7 /* SWAccessibilityCustomAction.m in Sources */,
 				810308921846579B00C378F0 /* SWCellScrollView.m in Sources */,
 				810308911846579B00C378F0 /* NSMutableArray+SWUtilityButtons.m in Sources */,
 				810308961846579B00C378F0 /* SWUtilityButtonView.m in Sources */,

--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
@@ -13,7 +13,9 @@
 - (void)sw_addUtilityButtonWithColor:(UIColor *)color title:(NSString *)title;
 - (void)sw_addUtilityButtonWithColor:(UIColor *)color attributedTitle:(NSAttributedString *)title;
 - (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon;
+- (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon accessibilityLabel:(NSString *)accessibilityLabel;
 - (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon;
+- (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon accessibilityLabel:(NSString *)accessibilityLabel;
 
 @end
 

--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.m
@@ -29,21 +29,33 @@
     [self addObject:button];
 }
 
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon
+- (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon accessibilityLabel:(NSString *)accessibilityLabel
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     button.backgroundColor = color;
     [button setImage:icon forState:UIControlStateNormal];
+    button.accessibilityLabel = accessibilityLabel;
     [self addObject:button];
 }
 
-- (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon {
+- (void)sw_addUtilityButtonWithColor:(UIColor *)color icon:(UIImage *)icon
+{
+    [self sw_addUtilityButtonWithColor:color icon:icon accessibilityLabel:nil];
+}
+
+- (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon accessibilityLabel:(NSString *)accessibilityLabel {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     button.backgroundColor = color;
     [button setImage:normalIcon forState:UIControlStateNormal];
     [button setImage:selectedIcon forState:UIControlStateHighlighted];
     [button setImage:selectedIcon forState:UIControlStateSelected];
+    button.accessibilityLabel = accessibilityLabel;
     [self addObject:button];
+}
+
+- (void)sw_addUtilityButtonWithColor:(UIColor *)color normalIcon:(UIImage *)normalIcon selectedIcon:(UIImage *)selectedIcon
+{
+    [self sw_addUtilityButtonWithColor:color normalIcon:normalIcon selectedIcon:selectedIcon accessibilityLabel:nil];
 }
 
 @end

--- a/SWTableViewCell/PodFiles/SWAccessibilityCustomAction.h
+++ b/SWTableViewCell/PodFiles/SWAccessibilityCustomAction.h
@@ -1,0 +1,18 @@
+//
+//  SWAccessibilityCustomAction.h
+//  SWTableViewCell
+//
+//  Created by Boris Dušek on 4/25/15.
+//  Copyright (c) 2015 Chris Wendel. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+@interface SWAccessibilityCustomAction : UIAccessibilityCustomAction
+
+@property(nonatomic, assign) BOOL right;
+@property(nonatomic, assign) NSInteger index;
+
+@end
+#endif

--- a/SWTableViewCell/PodFiles/SWAccessibilityCustomAction.m
+++ b/SWTableViewCell/PodFiles/SWAccessibilityCustomAction.m
@@ -1,0 +1,15 @@
+//
+//  SWAccessibilityCustomAction.m
+//  SWTableViewCell
+//
+//  Created by Boris Dušek (A11Y LTD.) on 4/25/15.
+//  Copyright (c) 2015 Chris Wendel. All rights reserved.
+//
+
+#import "SWAccessibilityCustomAction.h"
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+@implementation SWAccessibilityCustomAction
+
+@end
+#endif

--- a/SWTableViewCell/ViewController.m
+++ b/SWTableViewCell/ViewController.m
@@ -172,16 +172,20 @@
     
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:0.07 green:0.75f blue:0.16f alpha:1.0]
-                                                icon:[UIImage imageNamed:@"check.png"]];
+                                                icon:[UIImage imageNamed:@"check.png"] accessibilityLabel:@"Mark as done"];
+
+    UIImage *clockIcon = [UIImage imageNamed:@"clock.png"];
+    clockIcon.accessibilityLabel = @"Schedule";
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:1.0f green:1.0f blue:0.35f alpha:1.0]
-                                                icon:[UIImage imageNamed:@"clock.png"]];
+                                                icon:clockIcon];
+
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:1.0f green:0.231f blue:0.188f alpha:1.0]
                                                 icon:[UIImage imageNamed:@"cross.png"]];
     [leftUtilityButtons sw_addUtilityButtonWithColor:
      [UIColor colorWithRed:0.55f green:0.27f blue:0.07f alpha:1.0]
-                                                icon:[UIImage imageNamed:@"list.png"]];
+                                                icon:[UIImage imageNamed:@"list.png"] accessibilityLabel:@"Add to list"];
     
     return leftUtilityButtons;
 }


### PR DESCRIPTION
This enables using of utility button actions with VoiceOver and Switch Control.

To test with VoiceOver:
1. Turn on VoiceOver
2. Move VoiceOver cursor to a cell in the demo app (or any app using SWTableViewCell)
3. Select an action (by flicking up or down with one finger anywhere on the screen)
4. Perform the selected action (by double-tapping with one finger anywhere on the screen)

Patches donated by [A11Y LTD.](http://a11y.ltd.uk)
