### PR TITLE
Initialize override

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -49,6 +49,6 @@ typedef NS_ENUM(NSInteger, SWCellState)
 - (void)showRightUtilityButtonsAnimated:(BOOL)animated;
 
 - (BOOL)isUtilityButtonsHidden;
-- (void)initialize;
+- (void)initializer;
 
 @end

--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -49,5 +49,6 @@ typedef NS_ENUM(NSInteger, SWCellState)
 - (void)showRightUtilityButtonsAnimated:(BOOL)animated;
 
 - (BOOL)isUtilityButtonsHidden;
+- (void)initialize;
 
 @end


### PR DESCRIPTION
Allow overriding of initializer method for SWTableViewCell.   Useful for workaround required when using from a framework in Swift.
