### PR TITLE
Fixed missing UIKit import

### DIFF
--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Chris Wendel. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NSMutableArray (SWUtilityButtons)
 


### PR DESCRIPTION
Since the NSMutableArray+SWUtilityButtons category uses the UIButton class the UIKit header is actually needed instead of the Foundation one.

This fixes all build errors that are present if the source files of this project are included directly in another one.
