### PR TITLE
Fix buttons front when changing cell frame: send butons to back.

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -316,6 +316,9 @@ static NSString * const kTableViewPanState = @"state";
     }
     
     [self updateCellState];
+
+    [self.rightUtilityClipView.superview sendSubviewToBack:self.rightUtilityClipView];
+    [self.leftUtilityClipView.superview sendSubviewToBack:self.leftUtilityClipView];
 }
 
 - (void)setFrame:(CGRect)frame


### PR DESCRIPTION
When Custom Table View Cells and override the setFrame like this
- (void)setFrame:(CGRect)frame {
  frame.origin.x += inset;
  frame.size.width -= 2 \* inset;
  [super setFrame:frame];
  }

Then the rightUtilityClipView and leftUtilityClipView would go to front, while it supposed to be shaded when cell is in state kCellStateCenter.
