### PR TITLE
Import UIKit for swift project

### DIFF
--- a/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
+++ b/SWTableViewCell/PodFiles/NSMutableArray+SWUtilityButtons.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Chris Wendel. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NSMutableArray (SWUtilityButtons)
 


### PR DESCRIPTION
Import `UIKit` for swift project, or can not compile while just dragging `SWTableViewCell` to project (without Cocoapods).
