### PR TITLE
Left utility buttons visible on first load

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -301,8 +301,16 @@ static NSString * const kTableViewPanState = @"state";
 
 - (void)layoutSubviews
 {
-    [super layoutSubviews];
-    
+  
+    BOOL isPad = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad;
+    if (isPad == YES) {
+      layoutUpdating = YES;
+      [super layoutSubviews];
+      layoutUpdating = NO;
+    } else {
+      [super layoutSubviews];
+    }
+  
     // Offset the contentView origin so that it appears correctly w/rt the enclosing scroll view (to which we moved it).
     CGRect frame = self.contentView.frame;
     frame.origin.x = [self leftUtilityButtonsWidth];


### PR DESCRIPTION
As described in this issue
https://github.com/CEWendel/SWTableViewCell/issues/353, on the first
load of the view, cells show the left utility buttons. This solve the
problem.
