### PR TITLE
Make it so cells with a custom `accessoryView` are properly re-layouted on swipe.

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -616,7 +616,7 @@ static NSString * const kTableViewPanState = @"state";
         self.leftUtilityClipView.hidden = (self.leftUtilityClipConstraint.constant == 0);
         self.rightUtilityClipView.hidden = (self.rightUtilityClipConstraint.constant == 0);
         
-        if (self.accessoryType != UITableViewCellAccessoryNone && !self.editing) {
+        if ((self.accessoryType != UITableViewCellAccessoryNone || self.accessoryView != nil) && !self.editing) {
             UIView *accessory = [self.cellScrollView.superview.subviews lastObject];
             
             CGRect accessoryFrame = accessory.frame;


### PR DESCRIPTION
Currently, if you have a cell with the `accessoryView` property set to a custom view, its frame is not animated when there is a swipe. This change makes it so the conditional will take into account both the `accessoryType` not being `None` and the `accessoryView` not being `nil`.
