### PR TITLE
README.MD slightly corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Then, in the `tableView:cellForRowAtIndexPath:` method of your `UITableViewDataS
     
     cell.customLabel.text = @"Some Text";
     cell.customImageView.image = [UIImage imageNamed:@"MyAwesomeTableCellImage"];
-    [cell setCellHeight:cell.frame.size.height];
     return cell;
 }
 ```


### PR DESCRIPTION
In documentation README.MD the function setCellHeight is referenced and that function doesn't exists in code at least in last version. 

I remove from README.MD
