### PR TITLE
fix The second same cell tap response

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.h
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.h
@@ -32,6 +32,7 @@ typedef NS_ENUM(NSInteger, SWCellState)
 - (BOOL)swipeableTableViewCell:(SWTableViewCell *)cell canSwipeToState:(SWCellState)state;
 - (void)swipeableTableViewCellDidEndScrolling:(SWTableViewCell *)cell;
 - (void)swipeableTableViewCell:(SWTableViewCell *)cell didScroll:(UIScrollView *)scrollView;
+- (void)swipeableTableViewCellDidSelected:(SWTableViewCell *)cell;
 
 @end
 

--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -176,6 +176,17 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
                                [NSLayoutConstraint constraintWithItem:buttonView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationLessThanOrEqual toItem:self.contentView attribute:NSLayoutAttributeWidth multiplier:1.0 constant:-kUtilityButtonWidthDefault],
                                ]];
     }
+    
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapedInsideCell)];
+    tap.cancelsTouchesInView = NO;
+    [self.cellScrollView addGestureRecognizer:tap];
+}
+
+- (void) tapedInsideCell
+{
+    if ( _cellState == kCellStateCenter) {
+        [ _delegate swipeableTableViewCellDidSelected:self];
+    }
 }
 
 static NSString * const kTableViewPanState = @"state";


### PR DESCRIPTION
Avoid that didSelectedRowAtIndexPath of UITableView does not respond the second time when tapping the same Cell

Perhaps this is also the same problem
Menu for cell doesn't appear #184