### PR TITLE
Drop iOS 7 support not to crush in iOS 14

### DIFF
--- a/SWTableViewCell/PodFiles/SWTableViewCell.m
+++ b/SWTableViewCell/PodFiles/SWTableViewCell.m
@@ -9,8 +9,6 @@
 #import "SWTableViewCell.h"
 #import "SWUtilityButtonView.h"
 
-static NSString * const kTableViewCellContentView = @"UITableViewCellContentView";
-
 #define kSectionIndexWidth 15
 #define kAccessoryTrailingSpace 15
 #define kLongPressMinimumDuration 0.16f
@@ -91,12 +89,7 @@ static NSString * const kTableViewCellContentView = @"UITableViewCellContentView
     // Add the cell scroll view to the cell
     UIView *contentViewParent = self;
     UIView *clipViewParent = self.cellScrollView;
-    if (![NSStringFromClass([[self.subviews objectAtIndex:0] class]) isEqualToString:kTableViewCellContentView])
-    {
-        // iOS 7
-        contentViewParent = [self.subviews objectAtIndex:0];
-        clipViewParent = self;
-    }
+
     NSArray *cellSubviews = [contentViewParent subviews];
     [self insertSubview:self.cellScrollView atIndex:0];
     for (UIView *subview in cellSubviews)


### PR DESCRIPTION
My app suddenly crushed when I built it with Xcode 12.0 beta 6 and run in iOS 14 beta 8.
I found that `self.subviews` returns 0 during cell initialization for iOS 14.
The code was for supporting iOS 7 but it's reasonable to drop it.
After this change, the crush seems no longer appear.